### PR TITLE
Make `Converter` an interface-only class

### DIFF
--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -31,14 +31,6 @@ inline auto BOUNDARY_SAFE(const size_t& remain_size, const size_t& struct_size)
 }
 
 /**
- * Converter
- */
-void Converter::set_matcher(const std::string& filename)
-{
-  matc = make_unique<Matcher>(filename);
-}
-
-/**
  * PacketConverter
  */
 PacketConverter::PacketConverter(const uint32_t _l2_type) : l2_type(_l2_type) {}


### PR DESCRIPTION
This facilitates conversion to Rust.