### PR TITLE
Make `Matcher` work with `Read`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use producer::Kafka as KafkaProducer;
 use rmp_serde::Serializer;
 use serde::Serialize;
 use std::ffi::CStr;
+use std::fs::File;
 use std::os::raw::{c_char, c_int};
 use std::ptr;
 use std::slice;
@@ -470,7 +471,11 @@ pub unsafe extern "C" fn matcher_new(filename_ptr: *const c_char) -> *mut Matche
         Ok(s) => s,
         Err(_) => return ptr::null_mut(),
     };
-    let matcher = match Matcher::with_file(filename) {
+    let exp_file = match File::open(filename) {
+        Ok(f) => f,
+        Err(_) => return ptr::null_mut(),
+    };
+    let matcher = match Matcher::from_read(exp_file) {
         Ok(m) => m,
         Err(_) => return ptr::null_mut(),
     };

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -71,3 +71,16 @@ fn trim_to_rules(s: &str) -> Vec<&str> {
         })
         .collect::<Vec<_>>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Matcher;
+
+    #[test]
+    fn scan() {
+        let exps = "abc\nxyz\n";
+        let mut matcher = Matcher::from_read(exps.as_bytes()).expect("valid exps");
+        assert_eq!(matcher.scan(b"hello").expect("Ok"), false);
+        assert_eq!(matcher.scan(b"00xyz00").expect("Ok"), true);
+    }
+}


### PR DESCRIPTION
This allows testing `Matcher` without creating a file.